### PR TITLE
Feat. CrewManageView

### DIFF
--- a/safe/Sources/MainTabBarController.swift
+++ b/safe/Sources/MainTabBarController.swift
@@ -19,7 +19,7 @@ final class MainTabBarController: UITabBarController, UITabBarControllerDelegate
     }
 
     private func setupTabs() {
-        let SafeVS = UINavigationController(rootViewController: SafetyManagerViewController())
+        let SafeVS = UINavigationController(rootViewController: RiskDetectionViewController ())
         SafeVS.tabBarItem = UITabBarItem(title: "안전감시", image: UIImage(systemName: "shield.fill"), tag: 0)
 
         let LogVC = UINavigationController(rootViewController: LiskLogViewController())

--- a/safe/Sources/View/CrewManageView.swift
+++ b/safe/Sources/View/CrewManageView.swift
@@ -1,0 +1,154 @@
+//
+//  CrewManageView.swift
+//  safe
+//
+//  Created by 신찬솔 on 7/30/25.
+//
+
+import UIKit
+
+
+class CrewManageView: UIView {
+
+    // MARK: - Properties
+    private let containerView = UIView()
+    private let stackView = UIStackView()
+    private let statusButton = UIButton()
+    private let inviteButton = UIButton()
+    private let messageButton = UIButton()
+    private var selectedIndex: Int = 0 {
+        didSet {
+            updateTabSelection()
+            onTabSelected?(selectedIndex)
+        }
+    }
+
+    private let selectionIndicator = UIView()
+    private var indicatorLeadingConstraint: NSLayoutConstraint?
+    private var indicatorWidthConstraint: NSLayoutConstraint?
+    
+    let registerCrewView = RegisterCrewView()
+    
+    var onTabSelected: ((Int) -> Void)?
+
+    // MARK: - Init
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupTabs()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupTabs()
+    }
+
+    // MARK: - Setup
+    private func setupTabs() {
+        containerView.backgroundColor = .white
+        containerView.layer.cornerRadius = 16
+        containerView.layer.masksToBounds = false
+        containerView.layer.shadowColor = UIColor.black.cgColor
+        containerView.layer.shadowOpacity = 0.1
+        containerView.layer.shadowOffset = CGSize(width: 0, height: 2)
+        containerView.layer.shadowRadius = 4
+
+        addSubview(containerView)
+        containerView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            containerView.topAnchor.constraint(equalTo: topAnchor, constant: 8),
+            containerView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+            containerView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
+            containerView.heightAnchor.constraint(equalToConstant: 52)
+        ])
+
+        stackView.axis = .horizontal
+        stackView.distribution = .fillEqually
+        stackView.spacing = 8
+        stackView.alignment = .fill
+        containerView.addSubview(stackView)
+
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            stackView.topAnchor.constraint(equalTo: containerView.topAnchor, constant: 4),
+            stackView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor, constant: -4),
+            stackView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 4),
+            stackView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -4)
+        ])
+
+        configureButton(statusButton, title: "현황", iconName: "person.2", index: 0)
+        configureButton(inviteButton, title: "등록", iconName: "person.badge.plus", index: 1)
+        configureButton(messageButton, title: "공지", iconName: "message", index: 2)
+
+        containerView.addSubview(selectionIndicator)
+        selectionIndicator.backgroundColor = .orange
+        selectionIndicator.translatesAutoresizingMaskIntoConstraints = false
+        indicatorLeadingConstraint = selectionIndicator.leadingAnchor.constraint(equalTo: statusButton.leadingAnchor)
+        indicatorWidthConstraint = selectionIndicator.widthAnchor.constraint(equalTo: statusButton.widthAnchor)
+        NSLayoutConstraint.activate([
+            selectionIndicator.bottomAnchor.constraint(equalTo: containerView.bottomAnchor),
+            indicatorLeadingConstraint!,
+            indicatorWidthConstraint!,
+            selectionIndicator.heightAnchor.constraint(equalToConstant: 3)
+        ])
+        
+        addSubview(registerCrewView)
+        registerCrewView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            registerCrewView.topAnchor.constraint(equalTo: containerView.bottomAnchor, constant: 32),
+            registerCrewView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 4),
+            registerCrewView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -4),
+            registerCrewView.bottomAnchor.constraint(lessThanOrEqualTo: bottomAnchor, constant: -32)
+        ])
+        registerCrewView.isHidden = true
+
+        updateTabSelection()
+    }
+
+    private func configureButton(_ button: UIButton, title: String, iconName: String, index: Int) {
+        let config = UIImage.SymbolConfiguration(pointSize: 14, weight: .medium)
+        let image = UIImage(systemName: iconName, withConfiguration: config)
+        button.setImage(image, for: .normal)
+        button.setTitle(" " + title, for: .normal)
+        button.setTitleColor(.darkGray, for: .normal)
+        button.titleLabel?.font = .systemFont(ofSize: 14, weight: .medium)
+        button.tintColor = .darkGray
+        button.semanticContentAttribute = .forceLeftToRight
+        button.layer.cornerRadius = 12
+        button.layer.masksToBounds = true
+        button.addTarget(self, action: #selector(tabTapped(_:)), for: .touchUpInside)
+        button.tag = index
+        stackView.addArrangedSubview(button)
+        button.contentEdgeInsets = UIEdgeInsets(top: 0, left: 12, bottom: 0, right: 12)
+    }
+
+    // MARK: - Actions
+    @objc private func tabTapped(_ sender: UIButton) {
+        selectedIndex = sender.tag
+        // 콜백 또는 delegate로 선택 이벤트 전달 가능
+    }
+
+    private func updateTabSelection() {
+        let buttons = [statusButton, inviteButton, messageButton]
+        for (index, button) in buttons.enumerated() {
+            if index == selectedIndex {
+                button.setTitleColor(.orange, for: .normal)
+                button.tintColor = .orange
+            } else {
+                button.setTitleColor(.darkGray, for: .normal)
+                button.tintColor = .darkGray
+            }
+        }
+        UIView.animate(withDuration: 0.25) {
+            self.indicatorLeadingConstraint?.isActive = false
+            self.indicatorLeadingConstraint = self.selectionIndicator.centerXAnchor.constraint(equalTo: buttons[self.selectedIndex].centerXAnchor)
+            self.indicatorWidthConstraint?.isActive = false
+            self.indicatorWidthConstraint = self.selectionIndicator.widthAnchor.constraint(equalTo: buttons[self.selectedIndex].widthAnchor, multiplier: 0.75)
+            NSLayoutConstraint.activate([
+                self.indicatorLeadingConstraint!,
+                self.indicatorWidthConstraint!
+            ])
+            self.layoutIfNeeded()
+        }
+        registerCrewView.isHidden = selectedIndex != 1
+    }
+}

--- a/safe/Sources/View/CrewManageView.swift
+++ b/safe/Sources/View/CrewManageView.swift
@@ -10,7 +10,6 @@ import UIKit
 
 class CrewManageView: UIView {
 
-    // MARK: - Properties
     private let containerView = UIView()
     private let stackView = UIStackView()
     private let statusButton = UIButton()
@@ -26,12 +25,13 @@ class CrewManageView: UIView {
     private let selectionIndicator = UIView()
     private var indicatorLeadingConstraint: NSLayoutConstraint?
     private var indicatorWidthConstraint: NSLayoutConstraint?
+    private let currentCrewView = CurrentCrewView()
+    private let crewListSectionView = CrewListSectionView()
     
     let registerCrewView = RegisterCrewView()
     
     var onTabSelected: ((Int) -> Void)?
 
-    // MARK: - Init
     override init(frame: CGRect) {
         super.init(frame: frame)
         setupTabs()
@@ -42,7 +42,6 @@ class CrewManageView: UIView {
         setupTabs()
     }
 
-    // MARK: - Setup
     private func setupTabs() {
         containerView.backgroundColor = .white
         containerView.layer.cornerRadius = 16
@@ -91,6 +90,29 @@ class CrewManageView: UIView {
             selectionIndicator.heightAnchor.constraint(equalToConstant: 3)
         ])
         
+        addSubview(currentCrewView)
+        currentCrewView.translatesAutoresizingMaskIntoConstraints = false
+
+        addSubview(crewListSectionView)
+        crewListSectionView.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            currentCrewView.topAnchor.constraint(equalTo: containerView.bottomAnchor, constant: 16),
+            currentCrewView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 4),
+            currentCrewView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -4),
+            
+            crewListSectionView.topAnchor.constraint(equalTo: currentCrewView.bottomAnchor, constant: 16),
+            crewListSectionView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 4),
+            crewListSectionView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -4),
+            crewListSectionView.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor, constant: -32)
+        ])
+
+        currentCrewView.setContentCompressionResistancePriority(.required, for: .vertical)
+        crewListSectionView.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
+
+        currentCrewView.isHidden = false
+        crewListSectionView.isHidden = false
+        
         addSubview(registerCrewView)
         registerCrewView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
@@ -121,10 +143,8 @@ class CrewManageView: UIView {
         button.contentEdgeInsets = UIEdgeInsets(top: 0, left: 12, bottom: 0, right: 12)
     }
 
-    // MARK: - Actions
     @objc private func tabTapped(_ sender: UIButton) {
         selectedIndex = sender.tag
-        // 콜백 또는 delegate로 선택 이벤트 전달 가능
     }
 
     private func updateTabSelection() {
@@ -149,6 +169,8 @@ class CrewManageView: UIView {
             ])
             self.layoutIfNeeded()
         }
+        currentCrewView.isHidden = selectedIndex != 0
         registerCrewView.isHidden = selectedIndex != 1
+        crewListSectionView.isHidden = selectedIndex != 0
     }
 }

--- a/safe/Sources/View/CrewManageView.swift
+++ b/safe/Sources/View/CrewManageView.swift
@@ -109,6 +109,12 @@ class CrewManageView: UIView {
             crewListSectionView.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor, constant: -32)
         ])
 
+        crewListSectionView.onTapMessage = { [weak self] uid in
+            guard let self = self else { return }
+            self.selectedIndex = 2 
+            self.messageView.preselectRecipients([uid])
+        }
+
         addSubview(messageView)
         messageView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([

--- a/safe/Sources/View/CrewManageView.swift
+++ b/safe/Sources/View/CrewManageView.swift
@@ -27,7 +27,7 @@ class CrewManageView: UIView {
     private var indicatorWidthConstraint: NSLayoutConstraint?
     private let currentCrewView = CurrentCrewView()
     private let crewListSectionView = CrewListSectionView()
-    
+    private let messageView = CrewMessageView()
     let registerCrewView = RegisterCrewView()
     
     var onTabSelected: ((Int) -> Void)?
@@ -96,6 +96,8 @@ class CrewManageView: UIView {
         addSubview(crewListSectionView)
         crewListSectionView.translatesAutoresizingMaskIntoConstraints = false
 
+        
+        
         NSLayoutConstraint.activate([
             currentCrewView.topAnchor.constraint(equalTo: containerView.bottomAnchor, constant: 16),
             currentCrewView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 4),
@@ -106,6 +108,16 @@ class CrewManageView: UIView {
             crewListSectionView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -4),
             crewListSectionView.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor, constant: -32)
         ])
+
+        addSubview(messageView)
+        messageView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            messageView.topAnchor.constraint(equalTo: containerView.bottomAnchor, constant: 16),
+            messageView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 4),
+            messageView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -4),
+            messageView.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor, constant: -32)
+        ])
+        messageView.isHidden = true
 
         currentCrewView.setContentCompressionResistancePriority(.required, for: .vertical)
         crewListSectionView.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
@@ -170,7 +182,8 @@ class CrewManageView: UIView {
             self.layoutIfNeeded()
         }
         currentCrewView.isHidden = selectedIndex != 0
-        registerCrewView.isHidden = selectedIndex != 1
         crewListSectionView.isHidden = selectedIndex != 0
+        registerCrewView.isHidden = selectedIndex != 1
+        messageView.isHidden = selectedIndex != 2
     }
 }

--- a/safe/Sources/View/CrewMessageView.swift
+++ b/safe/Sources/View/CrewMessageView.swift
@@ -1,0 +1,375 @@
+//
+//  CrewMessageView.swift
+//  safe
+//
+//  Created by 신찬솔 on 8/14/25.
+//
+
+import UIKit
+import FirebaseAuth
+import FirebaseFirestore
+
+final class CrewMessageView: UIView {
+
+    private let titleLabel: UILabel = {
+        let lb = UILabel()
+        lb.text = "개별 메세지"
+        lb.font = .boldSystemFont(ofSize: 24)
+        lb.textColor = .label
+        lb.translatesAutoresizingMaskIntoConstraints = false
+        return lb
+    }()
+
+    private let recipientsTitleLabel: UILabel = {
+        let lb = UILabel()
+        lb.text = "수신자 선택"
+        lb.font = .systemFont(ofSize: 14, weight: .semibold)
+        lb.textColor = .secondaryLabel
+        lb.translatesAutoresizingMaskIntoConstraints = false
+        return lb
+    }()
+
+    private let recipientsScroll: UIScrollView = {
+        let sv = UIScrollView()
+        sv.showsHorizontalScrollIndicator = false
+        sv.alwaysBounceHorizontal = true
+        sv.translatesAutoresizingMaskIntoConstraints = false
+        return sv
+    }()
+
+    private let recipientsStack: UIStackView = {
+        let st = UIStackView()
+        st.axis = .horizontal
+        st.alignment = .center
+        st.spacing = 8
+        st.translatesAutoresizingMaskIntoConstraints = false
+        return st
+    }()
+
+    private let messageTitleLabel: UILabel = {
+        let lb = UILabel()
+        lb.text = "메세지 내용"
+        lb.font = .systemFont(ofSize: 16, weight: .semibold)
+        lb.textColor = .label
+        lb.translatesAutoresizingMaskIntoConstraints = false
+        return lb
+    }()
+
+    private let textViewContainer = UIView()
+    private let messageTextView: UITextView = {
+        let tv = UITextView()
+        tv.font = .systemFont(ofSize: 16)
+        tv.isScrollEnabled = true
+        tv.backgroundColor = .clear
+        tv.textContainerInset = UIEdgeInsets(top: 12, left: 12, bottom: 12, right: 12)
+        tv.translatesAutoresizingMaskIntoConstraints = false
+        return tv
+    }()
+    private let placeholderLabel: UILabel = {
+        let lb = UILabel()
+        lb.text = "개별 메세지를 입력하세요."
+        lb.font = .systemFont(ofSize: 16)
+        lb.textColor = .placeholderText
+        lb.translatesAutoresizingMaskIntoConstraints = false
+        return lb
+    }()
+
+    private let sendButton: UIButton = {
+        let bt = UIButton(type: .system)
+        bt.setTitle("메세지 전송", for: .normal)
+        bt.titleLabel?.font = .boldSystemFont(ofSize: 22)
+        bt.backgroundColor = UIColor.systemOrange
+        bt.setTitleColor(.white, for: .normal)
+        bt.layer.cornerRadius = 14
+        bt.contentEdgeInsets = UIEdgeInsets(top: 16, left: 20, bottom: 16, right: 20)
+        bt.translatesAutoresizingMaskIntoConstraints = false
+        return bt
+    }()
+
+    struct Member: Hashable {
+        let uid: String
+        let name: String
+        let phone: String
+    }
+    private var members: [Member] = []
+    private var selectedUIDs: Set<String> = [] { didSet { updateSendButtonState() } }
+
+    private var companyListener: ListenerRegistration?
+    private var memberListeners: [String: ListenerRegistration] = [:]
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+        fetchMembers()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupUI()
+        fetchMembers()
+    }
+
+    deinit {
+        companyListener?.remove()
+        memberListeners.values.forEach { $0.remove() }
+        memberListeners.removeAll()
+    }
+
+    private func setupUI() {
+        backgroundColor = .clear
+
+        addSubview(titleLabel)
+        addSubview(recipientsTitleLabel)
+        addSubview(recipientsScroll)
+        recipientsScroll.addSubview(recipientsStack)
+        addSubview(messageTitleLabel)
+        addSubview(textViewContainer)
+        textViewContainer.translatesAutoresizingMaskIntoConstraints = false
+        textViewContainer.backgroundColor = UIColor.secondarySystemBackground
+        textViewContainer.layer.cornerRadius = 14
+        textViewContainer.layer.masksToBounds = true
+        textViewContainer.addSubview(messageTextView)
+        textViewContainer.addSubview(placeholderLabel)
+        addSubview(sendButton)
+
+        messageTextView.delegate = self
+        sendButton.addTarget(self, action: #selector(didTapSend), for: .touchUpInside)
+
+        NSLayoutConstraint.activate([
+            titleLabel.topAnchor.constraint(equalTo: topAnchor, constant: 8),
+            titleLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+            titleLabel.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -16),
+
+            recipientsTitleLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 12),
+            recipientsTitleLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+            recipientsTitleLabel.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -16),
+
+            recipientsScroll.topAnchor.constraint(equalTo: recipientsTitleLabel.bottomAnchor, constant: 8),
+            recipientsScroll.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+            recipientsScroll.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
+            recipientsScroll.heightAnchor.constraint(equalToConstant: 140),
+
+            recipientsStack.topAnchor.constraint(equalTo: recipientsScroll.contentLayoutGuide.topAnchor),
+            recipientsStack.leadingAnchor.constraint(equalTo: recipientsScroll.contentLayoutGuide.leadingAnchor),
+            recipientsStack.trailingAnchor.constraint(equalTo: recipientsScroll.contentLayoutGuide.trailingAnchor),
+            recipientsStack.bottomAnchor.constraint(equalTo: recipientsScroll.contentLayoutGuide.bottomAnchor),
+            recipientsStack.heightAnchor.constraint(equalTo: recipientsScroll.frameLayoutGuide.heightAnchor),
+
+            messageTitleLabel.topAnchor.constraint(equalTo: recipientsScroll.bottomAnchor, constant: 16),
+            messageTitleLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+            messageTitleLabel.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -16),
+
+            textViewContainer.topAnchor.constraint(equalTo: messageTitleLabel.bottomAnchor, constant: 8),
+            textViewContainer.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+            textViewContainer.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
+            textViewContainer.heightAnchor.constraint(equalToConstant: 180),
+
+            messageTextView.topAnchor.constraint(equalTo: textViewContainer.topAnchor),
+            messageTextView.leadingAnchor.constraint(equalTo: textViewContainer.leadingAnchor),
+            messageTextView.trailingAnchor.constraint(equalTo: textViewContainer.trailingAnchor),
+            messageTextView.bottomAnchor.constraint(equalTo: textViewContainer.bottomAnchor),
+
+            placeholderLabel.topAnchor.constraint(equalTo: textViewContainer.topAnchor, constant: 12),
+            placeholderLabel.leadingAnchor.constraint(equalTo: textViewContainer.leadingAnchor, constant: 16),
+            placeholderLabel.trailingAnchor.constraint(lessThanOrEqualTo: textViewContainer.trailingAnchor, constant: -16),
+
+            sendButton.topAnchor.constraint(equalTo: textViewContainer.bottomAnchor, constant: 20),
+            sendButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+            sendButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
+            sendButton.heightAnchor.constraint(equalToConstant: 60),
+            bottomAnchor.constraint(greaterThanOrEqualTo: sendButton.bottomAnchor)
+        ])
+
+        setContentHuggingPriority(.required, for: .vertical)
+        setContentCompressionResistancePriority(.required, for: .vertical)
+    }
+
+    private func buildRecipientCards() {
+        recipientsStack.arrangedSubviews.forEach { v in
+            recipientsStack.removeArrangedSubview(v)
+            v.removeFromSuperview()
+        }
+
+        for m in members {
+            let card = RecipientCardView(model: .init(uid: m.uid, name: m.name))
+            card.isSelected = selectedUIDs.contains(m.uid)
+            card.addTarget(self, action: #selector(didToggleRecipient(_:)), for: .touchUpInside)
+            recipientsStack.addArrangedSubview(card)
+        }
+    }
+
+    private func updateSendButtonState() {
+        sendButton.alpha = selectedUIDs.isEmpty ? 0.5 : 1.0
+        sendButton.isEnabled = !selectedUIDs.isEmpty
+    }
+
+    @objc private func didToggleRecipient(_ sender: RecipientCardView) {
+        guard let uid = sender.model?.uid else { return }
+        if selectedUIDs.contains(uid) { selectedUIDs.remove(uid) } else { selectedUIDs.insert(uid) }
+        sender.isSelected.toggle()
+    }
+
+    @objc private func didTapSend() {
+        let text = messageTextView.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else {
+            let alert = UIAlertController(title: nil, message: "메세지를 입력해주세요.", preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: "확인", style: .default, handler: nil))
+            presentAlert(alert)
+            return
+        }
+
+        let alert = UIAlertController(title: nil, message: "메세지를 전송했습니다!", preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "확인", style: .default, handler: nil))
+        presentAlert(alert)
+    }
+
+    func fetchMembers() {
+        guard let currentUID = Auth.auth().currentUser?.uid else { return }
+        let db = Firestore.firestore()
+
+        db.collection("users").document(currentUID).getDocument { [weak self] snap, _ in
+            guard let self = self, let data = snap?.data(), let company = data["companyName"] as? String else { return }
+            self.companyListener?.remove()
+            self.companyListener = db.collection(company).addSnapshotListener { [weak self] qsnap, _ in
+                guard let self = self else { return }
+                var uids: [String] = []
+                qsnap?.documents.forEach { doc in
+                    if let uid = (doc["uid"] as? String) ?? doc.documentID as String? {
+                        uids.append(uid)
+                    }
+                }
+
+                self.memberListeners.values.forEach { $0.remove() }
+                self.memberListeners.removeAll()
+                self.members.removeAll()
+
+                let usersRef = db.collection("users")
+                uids.forEach { uid in
+                    let l = usersRef.document(uid).addSnapshotListener { [weak self] doc, _ in
+                        guard let self = self, let d = doc?.data() else { return }
+                        let name = (d["name"] as? String) ?? "-"
+                        let phone = (d["phoneNumber"] as? String) ?? "-"
+                        let member = Member(uid: uid, name: name, phone: phone)
+
+                        if let idx = self.members.firstIndex(where: { $0.uid == uid }) {
+                            self.members[idx] = member
+                        } else {
+                            self.members.append(member)
+                        }
+                        self.members.sort { $0.name < $1.name }
+                        self.buildRecipientCards()
+                    }
+                    self.memberListeners[uid] = l
+                }
+            }
+        }
+    }
+}
+
+extension CrewMessageView: UITextViewDelegate {
+    func textViewDidChange(_ textView: UITextView) {
+        placeholderLabel.isHidden = !textView.text.isEmpty
+    }
+}
+
+private final class RecipientCardView: UIControl {
+    struct Model { let uid: String; let name: String }
+    var model: Model?
+
+    private let container = UIView()
+    private let avatar = UIView()
+    private let initialLabel = UILabel()
+    private let nameLabel = UILabel()
+
+    init(model: Model) {
+        self.model = model
+        super.init(frame: .zero)
+        setup()
+    }
+
+    required init?(coder: NSCoder) { super.init(coder: coder); setup() }
+
+    private func setup() {
+        translatesAutoresizingMaskIntoConstraints = false
+        container.translatesAutoresizingMaskIntoConstraints = false
+        container.backgroundColor = UIColor.secondarySystemBackground
+        container.layer.cornerRadius = 14
+        container.isUserInteractionEnabled = false
+        container.layer.borderWidth = 1
+        container.layer.borderColor = UIColor.tertiaryLabel.withAlphaComponent(0.25).cgColor
+
+        avatar.translatesAutoresizingMaskIntoConstraints = false
+        avatar.backgroundColor = UIColor.systemOrange.withAlphaComponent(0.2)
+        avatar.layer.cornerRadius = 14
+
+        initialLabel.translatesAutoresizingMaskIntoConstraints = false
+        initialLabel.font = .boldSystemFont(ofSize: 24)
+        initialLabel.textAlignment = .center
+        initialLabel.textColor = .systemOrange
+
+        nameLabel.translatesAutoresizingMaskIntoConstraints = false
+        nameLabel.font = .boldSystemFont(ofSize: 18)
+        nameLabel.textColor = .label
+        nameLabel.textAlignment = .center
+
+        nameLabel.text = model?.name ?? "-"
+
+        addSubview(container)
+        container.addSubview(avatar)
+        container.addSubview(nameLabel)
+
+        if let n = model?.name, let f = n.first { initialLabel.text = String(f) } else { initialLabel.text = "?" }
+        avatar.addSubview(initialLabel)
+
+        NSLayoutConstraint.activate([
+            container.topAnchor.constraint(equalTo: topAnchor),
+            container.leadingAnchor.constraint(equalTo: leadingAnchor),
+            container.trailingAnchor.constraint(equalTo: trailingAnchor),
+            container.bottomAnchor.constraint(equalTo: bottomAnchor),
+
+            avatar.topAnchor.constraint(equalTo: container.topAnchor, constant: 12),
+            avatar.centerXAnchor.constraint(equalTo: container.centerXAnchor),
+            avatar.widthAnchor.constraint(equalToConstant: 56),
+            avatar.heightAnchor.constraint(equalToConstant: 56),
+
+            initialLabel.centerXAnchor.constraint(equalTo: avatar.centerXAnchor),
+            initialLabel.centerYAnchor.constraint(equalTo: avatar.centerYAnchor),
+
+            nameLabel.topAnchor.constraint(equalTo: avatar.bottomAnchor, constant: 8),
+            nameLabel.centerXAnchor.constraint(equalTo: container.centerXAnchor),
+            nameLabel.leadingAnchor.constraint(greaterThanOrEqualTo: container.leadingAnchor, constant: 8),
+            nameLabel.trailingAnchor.constraint(lessThanOrEqualTo: container.trailingAnchor, constant: -8),
+            nameLabel.bottomAnchor.constraint(lessThanOrEqualTo: container.bottomAnchor, constant: -12),
+
+            heightAnchor.constraint(equalToConstant: 140),
+            widthAnchor.constraint(greaterThanOrEqualToConstant: 96)
+        ])
+        updateAppearance()
+    }
+
+    private func updateAppearance() {
+        container.layer.borderColor = (isSelected ? UIColor.systemOrange : UIColor.tertiaryLabel.withAlphaComponent(0.25)).cgColor
+        container.layer.borderWidth = isSelected ? 2 : 1
+        container.backgroundColor = isSelected ? UIColor.systemOrange.withAlphaComponent(0.12) : UIColor.secondarySystemBackground
+    }
+
+    override var isSelected: Bool {
+        didSet { updateAppearance() }
+    }
+}
+
+private extension UIView {
+    func presentAlert(_ alert: UIAlertController) {
+        guard let vc = nearestViewController() else { return }
+        vc.present(alert, animated: true, completion: nil)
+    }
+
+    func nearestViewController() -> UIViewController? {
+        var responder: UIResponder? = self
+        while let r = responder {
+            if let vc = r as? UIViewController { return vc }
+            responder = r.next
+        }
+        return nil
+    }
+}

--- a/safe/Sources/View/CrewRowView.swift
+++ b/safe/Sources/View/CrewRowView.swift
@@ -1,0 +1,403 @@
+//
+//  CrewRowView.swift
+//  safe
+//
+//  Created by 신찬솔 on 8/14/25.
+//
+
+import UIKit
+import FirebaseAuth
+import FirebaseFirestore
+
+struct CrewMemberModel {
+    let uid: String
+    let employeeId: String
+    let name: String
+    let phoneNumber: String
+    let working: Bool
+    let resting: Bool
+}
+
+final class CrewRowView: UIView {
+
+    private let container = UIView()
+    private let avatarView = UIView()
+    private let badge = UILabel()
+    private let nameLabel = UILabel()
+    private let statusDot = UIView()
+    private let statusLabel = UILabel()
+    private let empIdLabel = UILabel()
+    private let phoneLabel = UILabel()
+    private let restButton = UIButton(type: .system)
+    private let messageButton = UIButton(type: .system)
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupUI()
+    }
+
+    func configure(with model: CrewMemberModel) {
+        let initial = model.name.isEmpty ? "#" : String(model.name.prefix(1))
+        badge.text = initial
+
+        nameLabel.text = model.name
+        empIdLabel.text = "사번 \(model.employeeId)"
+        
+        phoneLabel.text = model.phoneNumber.isEmpty ? "-" : model.phoneNumber
+
+        restButton.setTitle("☕️  휴식 알림", for: .normal)
+        messageButton.setTitle("✉️  개별 메세지", for: .normal)
+
+        let (text, color) = Self.statusTextColor(working: model.working, resting: model.resting)
+        statusLabel.text = text
+        statusDot.backgroundColor = color
+    }
+
+    private static func statusTextColor(working: Bool, resting: Bool) -> (String, UIColor) {
+        switch (working, resting) {
+        case (true, false): return ("근무중", UIColor.systemGreen)
+        case (true, true):  return ("휴식중", UIColor.systemBlue)
+        default:            return ("오프라인", UIColor.systemGray)
+        }
+    }
+
+    private func setupUI() {
+        backgroundColor = .clear
+
+        container.backgroundColor = UIColor.secondarySystemBackground
+        container.layer.cornerRadius = 16
+        container.layer.shadowColor = UIColor.black.withAlphaComponent(0.08).cgColor
+        container.layer.shadowOpacity = 1
+        container.layer.shadowOffset = CGSize(width: 0, height: 2)
+        container.layer.shadowRadius = 6
+        container.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(container)
+
+        NSLayoutConstraint.activate([
+            container.topAnchor.constraint(equalTo: topAnchor, constant: 6),
+            container.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+            container.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
+            container.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -6)
+        ])
+
+        avatarView.translatesAutoresizingMaskIntoConstraints = false
+        avatarView.backgroundColor = UIColor.systemOrange.withAlphaComponent(0.18)
+        avatarView.layer.cornerRadius = 18
+        avatarView.layer.masksToBounds = true
+        avatarView.widthAnchor.constraint(equalToConstant: 72).isActive = true
+        avatarView.heightAnchor.constraint(equalToConstant: 72).isActive = true
+
+        badge.textAlignment = .center
+        badge.font = .boldSystemFont(ofSize: 36)
+        badge.textColor = .systemOrange
+        badge.backgroundColor = .clear
+        badge.translatesAutoresizingMaskIntoConstraints = false
+        avatarView.addSubview(badge)
+        NSLayoutConstraint.activate([
+            badge.centerXAnchor.constraint(equalTo: avatarView.centerXAnchor),
+            badge.centerYAnchor.constraint(equalTo: avatarView.centerYAnchor)
+        ])
+
+        nameLabel.font = .boldSystemFont(ofSize: 24)
+        nameLabel.textColor = .label
+        nameLabel.setContentHuggingPriority(.defaultHigh, for: .vertical)
+
+        statusDot.translatesAutoresizingMaskIntoConstraints = false
+        statusDot.layer.cornerRadius = 6
+        statusDot.widthAnchor.constraint(equalToConstant: 12).isActive = true
+        statusDot.heightAnchor.constraint(equalToConstant: 12).isActive = true
+
+        statusLabel.font = .systemFont(ofSize: 16)
+        statusLabel.textColor = .label
+        statusLabel.setContentHuggingPriority(.defaultLow, for: .horizontal)
+
+        let statusStack = UIStackView(arrangedSubviews: [statusDot, statusLabel])
+        statusStack.axis = .horizontal
+        statusStack.spacing = 8
+        statusStack.alignment = .center
+
+        empIdLabel.font = .systemFont(ofSize: 16, weight: .medium)
+        empIdLabel.textColor = .secondaryLabel
+        empIdLabel.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+
+        let phoneIcon = UIImageView(image: UIImage(systemName: "phone"))
+        phoneIcon.tintColor = .secondaryLabel
+        phoneIcon.contentMode = .scaleAspectFit
+        phoneIcon.translatesAutoresizingMaskIntoConstraints = false
+        phoneIcon.widthAnchor.constraint(equalToConstant: 16).isActive = true
+        phoneIcon.heightAnchor.constraint(equalToConstant: 16).isActive = true
+
+        phoneLabel.font = .systemFont(ofSize: 16, weight: .medium)
+        phoneLabel.textColor = .label
+        phoneLabel.setContentHuggingPriority(.defaultLow, for: .horizontal)
+
+        nameLabel.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        statusLabel.setContentHuggingPriority(.required, for: .horizontal)
+        statusDot.setContentHuggingPriority(.required, for: .horizontal)
+        let nameRow = UIStackView(arrangedSubviews: [nameLabel, UIView(), statusStack])
+        nameRow.axis = .horizontal
+        nameRow.alignment = .firstBaseline
+        nameRow.spacing = 12
+
+        let spacer = UIView(); spacer.translatesAutoresizingMaskIntoConstraints = false; spacer.widthAnchor.constraint(equalToConstant: 16).isActive = true
+        let infoRow = UIStackView(arrangedSubviews: [empIdLabel, spacer, phoneIcon, phoneLabel])
+        infoRow.axis = .horizontal
+        infoRow.alignment = .center
+        infoRow.spacing = 10
+
+        let leftColumn = UIStackView(arrangedSubviews: [nameRow, infoRow])
+        leftColumn.axis = .vertical
+        leftColumn.spacing = 8
+        leftColumn.translatesAutoresizingMaskIntoConstraints = false
+        
+        let headerRow = UIStackView(arrangedSubviews: [avatarView, leftColumn])
+        headerRow.axis = .horizontal
+        headerRow.alignment = .center
+        headerRow.spacing = 16
+        headerRow.translatesAutoresizingMaskIntoConstraints = false
+
+        restButton.translatesAutoresizingMaskIntoConstraints = false
+        restButton.backgroundColor = UIColor.systemOrange
+        restButton.tintColor = .white
+        restButton.titleLabel?.font = .boldSystemFont(ofSize: 14)
+        restButton.layer.cornerRadius = 12
+        restButton.contentEdgeInsets = UIEdgeInsets(top: 10, left: 14, bottom: 10, right: 14)
+        restButton.addTarget(self, action: #selector(didTapRestButton), for: .touchUpInside)
+
+        messageButton.translatesAutoresizingMaskIntoConstraints = false
+        messageButton.backgroundColor = .white
+        messageButton.tintColor = .label
+        messageButton.titleLabel?.font = .boldSystemFont(ofSize: 14)
+        messageButton.layer.cornerRadius = 12
+        messageButton.layer.borderWidth = 1
+        messageButton.layer.borderColor = UIColor.systemGray4.cgColor
+        messageButton.contentEdgeInsets = UIEdgeInsets(top: 10, left: 14, bottom: 10, right: 14)
+
+        let buttonSpacer = UIView()
+        let buttonRow = UIStackView(arrangedSubviews: [restButton, buttonSpacer, messageButton])
+        buttonRow.axis = .horizontal
+        buttonRow.alignment = .center
+        buttonRow.spacing = 16
+        buttonRow.translatesAutoresizingMaskIntoConstraints = false
+        buttonRow.distribution = .fill
+        restButton.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        restButton.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        messageButton.setContentHuggingPriority(.required, for: .horizontal)
+        messageButton.setContentCompressionResistancePriority(.required, for: .horizontal)
+
+        let verticalStack = UIStackView(arrangedSubviews: [headerRow, buttonRow])
+        verticalStack.axis = .vertical
+        verticalStack.spacing = 8
+        verticalStack.translatesAutoresizingMaskIntoConstraints = false
+
+        container.addSubview(verticalStack)
+
+        NSLayoutConstraint.activate([
+            verticalStack.topAnchor.constraint(equalTo: container.topAnchor, constant: 14),
+            verticalStack.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 16),
+            verticalStack.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -16),
+            verticalStack.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: -14),
+
+            avatarView.widthAnchor.constraint(equalToConstant: 56),
+            avatarView.heightAnchor.constraint(equalToConstant: 56),
+            restButton.heightAnchor.constraint(equalToConstant: 48),
+            restButton.widthAnchor.constraint(greaterThanOrEqualToConstant: 140),
+            messageButton.heightAnchor.constraint(equalToConstant: 48),
+            messageButton.widthAnchor.constraint(greaterThanOrEqualToConstant: 140),
+        ])
+
+    }
+    
+    @objc private func didTapRestButton() {
+        let alert = UIAlertController(title: nil, message: "휴식알림을 전송했습니다!", preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "확인", style: .default, handler: nil))
+        presentAlert(alert)
+    }
+
+    private func presentAlert(_ alert: UIAlertController) {
+        guard let vc = nearestViewController() else { return }
+        vc.present(alert, animated: true, completion: nil)
+    }
+
+    private func nearestViewController() -> UIViewController? {
+        var responder: UIResponder? = self
+        while let r = responder {
+            if let vc = r as? UIViewController { return vc }
+            responder = r.next
+        }
+        return nil
+    }
+}
+
+final class CrewListSectionView: UIView {
+
+    private let titleLabel: UILabel = {
+        let lb = UILabel()
+        lb.text = "근로자 목록"
+        lb.font = .boldSystemFont(ofSize: 24)
+        lb.textColor = .label
+        lb.translatesAutoresizingMaskIntoConstraints = false
+        return lb
+    }()
+
+    private let countBadge: UILabel = {
+        let lb = UILabel()
+        lb.textAlignment = .center
+        lb.font = .boldSystemFont(ofSize: 12)
+        lb.textColor = .label
+        lb.backgroundColor = UIColor.secondarySystemFill
+        lb.layer.cornerRadius = 18
+        lb.layer.masksToBounds = true
+        lb.translatesAutoresizingMaskIntoConstraints = false
+        lb.text = "총 0명"
+        return lb
+    }()
+
+    private let scrollView = UIScrollView()
+    private let stackView = UIStackView()
+    private let db = Firestore.firestore()
+    private var companyListener: ListenerRegistration?
+    private var userListeners: [String: ListenerRegistration] = [:]
+    private var members: [String: CrewMemberModel] = [:]
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+        start()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupUI()
+        start()
+    }
+
+    deinit {
+        companyListener?.remove()
+        userListeners.values.forEach { $0.remove() }
+        userListeners.removeAll()
+    }
+
+    private func setupUI() {
+        backgroundColor = .clear
+
+        addSubview(titleLabel)
+        addSubview(countBadge)
+
+        NSLayoutConstraint.activate([
+            titleLabel.topAnchor.constraint(equalTo: topAnchor),
+            titleLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+
+            countBadge.centerYAnchor.constraint(equalTo: titleLabel.centerYAnchor),
+            countBadge.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
+            countBadge.heightAnchor.constraint(equalToConstant: 36),
+            countBadge.widthAnchor.constraint(greaterThanOrEqualToConstant: 86)
+        ])
+
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(scrollView)
+
+        NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 12),
+            scrollView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: bottomAnchor)
+        ])
+
+        stackView.axis = .vertical
+        stackView.spacing = 14
+        stackView.alignment = .fill
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.addSubview(stackView)
+
+        let content = scrollView.contentLayoutGuide
+        let frameGuide = scrollView.frameLayoutGuide
+
+        NSLayoutConstraint.activate([
+            stackView.topAnchor.constraint(equalTo: content.topAnchor, constant: 4),
+            stackView.leadingAnchor.constraint(equalTo: content.leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: content.trailingAnchor),
+            stackView.bottomAnchor.constraint(equalTo: content.bottomAnchor, constant: -8),
+            stackView.widthAnchor.constraint(equalTo: frameGuide.widthAnchor)
+        ])
+
+        let minH = heightAnchor.constraint(greaterThanOrEqualToConstant: 200)
+        minH.priority = .defaultLow
+        minH.isActive = true
+    }
+
+    private func start() {
+        guard let me = Auth.auth().currentUser?.uid else { return }
+
+        db.collection("users").document(me).getDocument { [weak self] snap, err in
+            guard let self = self else { return }
+            if let companyName = snap?.data()?["companyName"] as? String, !companyName.isEmpty {
+                self.companyListener?.remove()
+                self.companyListener = self.db.collection(companyName)
+                    .addSnapshotListener { [weak self] qsnap, err in
+                        guard let self = self else { return }
+                        guard let docs = qsnap?.documents else { return }
+
+                        let uids: [String] = docs.compactMap {
+                            if let uid = $0.data()["uid"] as? String, !uid.isEmpty {
+                                return uid
+                            } else {
+                                return $0.documentID
+                            }
+                        }
+
+                        for (uid, l) in self.userListeners where !uids.contains(uid) {
+                            l.remove()
+                            self.userListeners.removeValue(forKey: uid)
+                            self.members.removeValue(forKey: uid)
+                        }
+
+                        for uid in uids where self.userListeners[uid] == nil {
+                            let l = self.db.collection("users").document(uid).addSnapshotListener { [weak self] dsnap, err in
+                                guard let self = self else { return }
+                                guard let d = dsnap?.data() else { return }
+                                let employeeId = d["employeeId"] as? String ?? ""
+                                let name = d["name"] as? String ?? ""
+                                let phone = d["phoneNumber"] as? String ?? ""
+                                let working = d["working"] as? Bool ?? false
+                                let resting = d["resting"] as? Bool ?? false
+                                let model = CrewMemberModel(
+                                    uid: uid,
+                                    employeeId: employeeId,
+                                    name: name,
+                                    phoneNumber: phone,
+                                    working: working,
+                                    resting: resting
+                                )
+                                self.members[uid] = model
+                                DispatchQueue.main.async {
+                                    self.render()
+                                }
+                            }
+                            self.userListeners[uid] = l
+                        }
+                        DispatchQueue.main.async { self.render() }
+                    }
+            } else {
+                return
+            }
+        }
+    }
+
+    private func render() {
+        countBadge.text = "총 \(members.count)명"
+        stackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
+
+        let sorted = members.values.sorted { $0.name < $1.name }
+        for m in sorted {
+            let row = CrewRowView()
+            row.configure(with: m)
+            stackView.addArrangedSubview(row)
+        }
+    }
+}

--- a/safe/Sources/View/CrewRowView.swift
+++ b/safe/Sources/View/CrewRowView.swift
@@ -87,7 +87,7 @@ final class CrewRowView: UIView {
 
         avatarView.translatesAutoresizingMaskIntoConstraints = false
         avatarView.backgroundColor = UIColor.systemOrange.withAlphaComponent(0.18)
-        avatarView.layer.cornerRadius = 18
+        avatarView.layer.cornerRadius = 14
         avatarView.layer.masksToBounds = true
         avatarView.widthAnchor.constraint(equalToConstant: 72).isActive = true
         avatarView.heightAnchor.constraint(equalToConstant: 72).isActive = true

--- a/safe/Sources/View/CrewRowView.swift
+++ b/safe/Sources/View/CrewRowView.swift
@@ -31,6 +31,9 @@ final class CrewRowView: UIView {
     private let restButton = UIButton(type: .system)
     private let messageButton = UIButton(type: .system)
     
+    var onTapMessage: ((String) -> Void)?
+    private var currentModel: CrewMemberModel?
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         setupUI()
@@ -42,6 +45,7 @@ final class CrewRowView: UIView {
     }
 
     func configure(with model: CrewMemberModel) {
+        currentModel = model
         let initial = model.name.isEmpty ? "#" : String(model.name.prefix(1))
         badge.text = initial
 
@@ -177,6 +181,7 @@ final class CrewRowView: UIView {
         messageButton.layer.borderWidth = 1
         messageButton.layer.borderColor = UIColor.systemGray4.cgColor
         messageButton.contentEdgeInsets = UIEdgeInsets(top: 10, left: 14, bottom: 10, right: 14)
+        messageButton.addTarget(self, action: #selector(didTapMessageButton), for: .touchUpInside)
 
         let buttonSpacer = UIView()
         let buttonRow = UIStackView(arrangedSubviews: [restButton, buttonSpacer, messageButton])
@@ -213,6 +218,11 @@ final class CrewRowView: UIView {
 
     }
     
+    @objc private func didTapMessageButton() {
+        guard let uid = currentModel?.uid else { return }
+        onTapMessage?(uid)
+    }
+
     @objc private func didTapRestButton() {
         let alert = UIAlertController(title: nil, message: "휴식알림을 전송했습니다!", preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: "확인", style: .default, handler: nil))
@@ -264,6 +274,8 @@ final class CrewListSectionView: UIView {
     private var companyListener: ListenerRegistration?
     private var userListeners: [String: ListenerRegistration] = [:]
     private var members: [String: CrewMemberModel] = [:]
+
+    var onTapMessage: ((String) -> Void)?
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -397,6 +409,9 @@ final class CrewListSectionView: UIView {
         for m in sorted {
             let row = CrewRowView()
             row.configure(with: m)
+            row.onTapMessage = { [weak self] uid in
+                self?.onTapMessage?(uid)
+            }
             stackView.addArrangedSubview(row)
         }
     }

--- a/safe/Sources/View/CurrentCrewView.swift
+++ b/safe/Sources/View/CurrentCrewView.swift
@@ -1,0 +1,284 @@
+//
+//  CurrentCrewView.swift
+//  safe
+//
+//  Created by 신찬솔 on 8/13/25.
+//
+
+import UIKit
+import FirebaseAuth
+import FirebaseFirestore
+
+class CurrentCrewView: UIView {
+    
+    private let countersStack = UIStackView()
+    private let workingCard = StatCard(title: "근무중")
+    private let restingCard = StatCard(title: "휴식중")
+    private let offlineCard = StatCard(title: "오프라인")
+    private let titleLabel: UILabel = {
+        let l = UILabel()
+        l.text = "현장 현황"
+        l.font = .systemFont(ofSize: 24, weight: .bold)
+        l.textColor = .label
+        return l
+    }()
+    private let restAllButton = UIButton(type: .system)
+
+    private var memberListeners: [String: ListenerRegistration] = [:]
+    private var companyListener: ListenerRegistration?
+
+    private var members: [String: MemberSnapshot] = [:]
+
+    struct MemberSnapshot {
+        let uid: String
+        let name: String
+        let phone: String
+        let working: Bool
+        let resting: Bool
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+        startListening()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupUI()
+        startListening()
+    }
+
+    deinit {
+        companyListener?.remove()
+        memberListeners.values.forEach { $0.remove() }
+    }
+
+    private func setupUI() {
+        backgroundColor = .clear
+
+        let headerStack = UIStackView(arrangedSubviews: [titleLabel, UIView(), restAllButton])
+        headerStack.axis = .horizontal
+        headerStack.alignment = .center
+        headerStack.spacing = 12
+        addSubview(headerStack)
+        headerStack.translatesAutoresizingMaskIntoConstraints = false
+
+        countersStack.axis = .horizontal
+        countersStack.alignment = .center
+        countersStack.distribution = .fillEqually
+        countersStack.spacing = 12
+
+        [workingCard, restingCard, offlineCard].forEach { countersStack.addArrangedSubview($0) }
+
+        addSubview(countersStack)
+        countersStack.translatesAutoresizingMaskIntoConstraints = false
+
+        restAllButton.setTitle("전체 휴식 알림 전송", for: .normal)
+        restAllButton.backgroundColor = .systemOrange
+        restAllButton.setTitleColor(.white, for: .normal)
+        restAllButton.layer.cornerRadius = 10
+        restAllButton.titleLabel?.font = .systemFont(ofSize: 12, weight: .semibold)
+        restAllButton.translatesAutoresizingMaskIntoConstraints = false
+        restAllButton.addTarget(self, action: #selector(restAllButtonTapped), for: .touchUpInside)
+
+        NSLayoutConstraint.activate([
+            headerStack.topAnchor.constraint(equalTo: topAnchor, constant: 8),
+            headerStack.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+            headerStack.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
+
+            restAllButton.heightAnchor.constraint(equalToConstant: 30),
+            restAllButton.widthAnchor.constraint(equalToConstant: 120),
+
+            countersStack.topAnchor.constraint(equalTo: headerStack.bottomAnchor, constant: 16),
+            countersStack.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+            countersStack.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
+            countersStack.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -8)
+        ])
+
+        setContentHuggingPriority(.required, for: .vertical)
+        setContentCompressionResistancePriority(.required, for: .vertical)
+
+        workingCard.applyColors(bg: UIColor.systemGreen.withAlphaComponent(0.15), title: UIColor.systemGreen, count: UIColor.systemGreen)
+        restingCard.applyColors(bg: UIColor.systemBlue.withAlphaComponent(0.15), title: UIColor.systemBlue, count: UIColor.systemBlue)
+        offlineCard.applyColors(bg: UIColor.systemGray5, title: UIColor.label, count: UIColor.label)
+
+        updateCounters()
+    }
+
+    @objc private func restAllButtonTapped() {
+        let alert = UIAlertController(title: nil, message: "전체휴식알림을 보냈습니다!", preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "확인", style: .default, handler: nil))
+        presentAlert(alert)
+    }
+
+    private func startListening() {
+        guard let uid = Auth.auth().currentUser?.uid else { return }
+        let db = Firestore.firestore()
+
+        db.collection("users").document(uid).getDocument { [weak self] snap, err in
+            guard let self = self else { return }
+            if let err = err {
+                print("회사명 로드 실패: \(err.localizedDescription)")
+                return
+            }
+            guard let data = snap?.data(), let companyName = data["companyName"] as? String else {
+                print("회사명 없음")
+                return
+            }
+            self.listenCompanyCollection(named: companyName)
+        }
+    }
+
+    private func listenCompanyCollection(named companyName: String) {
+        let db = Firestore.firestore()
+
+        companyListener?.remove()
+        memberListeners.values.forEach { $0.remove() }
+        memberListeners.removeAll()
+        members.removeAll()
+        updateCounters()
+
+        companyListener = db.collection(companyName).addSnapshotListener { [weak self] snapshot, error in
+            guard let self = self else { return }
+            if let error = error {
+                print("회사 컬렉션 listen 실패: \(error.localizedDescription)")
+                return
+            }
+            let docs = snapshot?.documents ?? []
+            let uids = Set(docs.map { $0.documentID })
+
+            for (uid, listener) in self.memberListeners where !uids.contains(uid) {
+                listener.remove()
+                self.memberListeners.removeValue(forKey: uid)
+                self.members.removeValue(forKey: uid)
+            }
+
+            for uid in uids where self.memberListeners[uid] == nil {
+                self.attachMemberListener(uid: uid)
+            }
+            DispatchQueue.main.async {
+                self.updateCounters()
+            }
+        }
+    }
+
+    private func attachMemberListener(uid: String) {
+        let db = Firestore.firestore()
+        let listener = db.collection("users").document(uid).addSnapshotListener { [weak self] doc, err in
+            guard let self = self else { return }
+            if let err = err {
+                print("멤버 리스너 실패(\(uid)): \(err.localizedDescription)")
+                return
+            }
+            guard let d = doc?.data() else { return }
+            let name = (d["name"] as? String) ?? "이름없음"
+            let phone = (d["phoneNumber"] as? String) ?? "-"
+            let working = (d["working"] as? Bool) ?? false
+            let resting = (d["resting"] as? Bool) ?? false
+
+            let m = MemberSnapshot(uid: uid, name: name, phone: phone, working: working, resting: resting)
+            self.members[uid] = m
+            DispatchQueue.main.async {
+                self.updateCounters()
+            }
+        }
+        memberListeners[uid] = listener
+    }
+
+    private func updateCounters() {
+        var workingCnt = 0, restingCnt = 0, offlineCnt = 0
+        for m in members.values {
+            switch (m.working, m.resting) {
+            case (true, false): workingCnt += 1
+            case (true, true):  restingCnt += 1
+            case (false, false): offlineCnt += 1
+            default: offlineCnt += 1
+            }
+        }
+        workingCard.count = workingCnt
+        restingCard.count = restingCnt
+        offlineCard.count = offlineCnt
+    }
+
+
+    private func statusText(for m: MemberSnapshot) -> String {
+        switch (m.working, m.resting) {
+        case (true, false): return "근무중"
+        case (true, true):  return "휴식중"
+        case (false, false): return "오프라인"
+        default: return "오프라인"
+        }
+    }
+
+    private func statusColor(for m: MemberSnapshot) -> UIColor {
+        switch (m.working, m.resting) {
+        case (true, false): return UIColor.systemGreen
+        case (true, true):  return UIColor.systemBlue
+        case (false, false): return UIColor.systemGray
+        default: return UIColor.systemGray
+        }
+    }
+    
+    private final class StatCard: UIView {
+        private let titleLabel = UILabel()
+        private let countLabel = UILabel()
+
+        var count: Int = 0 { didSet { countLabel.text = "\(count)" } }
+
+        init(title: String) {
+            super.init(frame: .zero)
+            layer.cornerRadius = 16
+            backgroundColor = UIColor.secondarySystemBackground
+            layer.shadowColor = UIColor.black.cgColor
+            layer.shadowOpacity = 0.15
+            layer.shadowRadius = 10
+            layer.shadowOffset = CGSize(width: 0, height: 2)
+
+            titleLabel.text = title
+            titleLabel.font = .systemFont(ofSize: 18, weight: .semibold)
+            titleLabel.textColor = .label
+            titleLabel.textAlignment = .center
+
+            countLabel.text = "0"
+            countLabel.font = .systemFont(ofSize: 44, weight: .bold)
+            countLabel.textColor = .label
+            countLabel.textAlignment = .center
+
+            let v = UIStackView(arrangedSubviews: [UIView(), titleLabel, UIView(), countLabel, UIView()])
+            v.axis = .vertical
+            v.spacing = 8
+            addSubview(v)
+            v.translatesAutoresizingMaskIntoConstraints = false
+            NSLayoutConstraint.activate([
+                v.topAnchor.constraint(equalTo: topAnchor, constant: 12),
+                v.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+                v.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
+                v.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -12)
+            ])
+        }
+
+        required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+        func applyColors(bg: UIColor, title: UIColor, count: UIColor) {
+            backgroundColor = bg
+            titleLabel.textColor = title
+            countLabel.textColor = count
+        }
+    }
+
+    private func presentAlert(_ alert: UIAlertController) {
+        guard let vc = nearestViewController() else { return }
+        vc.present(alert, animated: true, completion: nil)
+    }
+
+    private func nearestViewController() -> UIViewController? {
+        var responder: UIResponder? = self
+        while let r = responder {
+            if let vc = r as? UIViewController { return vc }
+            responder = r.next
+        }
+        return nil
+    }
+
+}

--- a/safe/Sources/View/RegisterCrewView.swift
+++ b/safe/Sources/View/RegisterCrewView.swift
@@ -1,0 +1,158 @@
+//
+//  RegisterCrewView.swift
+//  safe
+//
+//  Created by 신찬솔 on 7/31/25.
+//
+
+import UIKit
+
+
+
+class RegisterCrewView: UIView {
+
+    private let cardView: UIView = {
+        let view = UIView()
+        view.layer.cornerRadius = 12
+        view.backgroundColor = .white
+        view.layer.shadowColor = UIColor.black.cgColor
+        view.layer.shadowOpacity = 0.1
+        view.layer.shadowOffset = CGSize(width: 0, height: 2)
+        view.layer.shadowRadius = 4
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+    
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "근로자 등록"
+        label.font = UIFont.boldSystemFont(ofSize: 20)
+        label.textColor = .black
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    private let idLabel: UILabel = {
+        let label = UILabel()
+        label.text = "사번"
+        label.font = UIFont.systemFont(ofSize: 14, weight: .medium)
+        label.textColor = .darkGray
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+     let employeeTextField: UITextField = {
+        let textField = UITextField()
+        textField.placeholder = "사번을 입력해주세요"
+        textField.borderStyle = .roundedRect
+        textField.heightAnchor.constraint(equalToConstant: 48).isActive = true
+        textField.translatesAutoresizingMaskIntoConstraints = false
+        return textField
+    }()
+    
+    // infoLabel을 감싸는 카드 뷰 추가
+    private let infoCardView: UIView = {
+        let view = UIView()
+        view.backgroundColor = UIColor(red: 0.9, green: 0.95, blue: 1.0, alpha: 1.0)
+        view.layer.cornerRadius = 8
+        view.layer.shadowColor = UIColor.black.cgColor
+        view.layer.shadowOpacity = 0.05
+        view.layer.shadowOffset = CGSize(width: 0, height: 2)
+        view.layer.shadowRadius = 4
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    private let infoTitleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "등록 안내"
+        label.font = UIFont.boldSystemFont(ofSize: 15)
+        label.textColor = UIColor(red: 0.0, green: 0.2, blue: 0.6, alpha: 1.0)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private let infoLabel: UILabel = {
+        let label = UILabel()
+        label.text = "입력된 사번을 기반으로 근로자가 등록됩니다.\n등록된 근로자는 관리자가 관리할 수 있습니다."
+        label.font = UIFont.systemFont(ofSize: 13)
+        label.textColor = .darkGray
+        label.numberOfLines = 0
+        label.textAlignment = .left
+        label.setContentHuggingPriority(.required, for: .vertical)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+     let inviteButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle("✉️ 근무자 등록", for: .normal)
+        button.setTitleColor(.white, for: .normal)
+        button.backgroundColor = UIColor(red: 1.0, green: 0.6, blue: 0.3, alpha: 1.0)
+        button.titleLabel?.font = UIFont.boldSystemFont(ofSize: 16)
+        button.layer.cornerRadius = 8
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupView()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupView()
+    }
+
+    private func setupView() {
+        backgroundColor = .clear
+        addSubview(cardView)
+
+        cardView.addSubview(titleLabel)
+        cardView.addSubview(idLabel)
+        cardView.addSubview(employeeTextField)
+        cardView.addSubview(infoCardView)
+        infoCardView.addSubview(infoTitleLabel)
+        infoCardView.addSubview(infoLabel)
+        cardView.addSubview(inviteButton)
+
+        NSLayoutConstraint.activate([
+            cardView.topAnchor.constraint(equalTo: topAnchor, constant: 24),
+            cardView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20),
+            cardView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -20),
+            cardView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -24),
+
+            titleLabel.topAnchor.constraint(equalTo: cardView.topAnchor, constant: 24),
+            titleLabel.leadingAnchor.constraint(equalTo: cardView.leadingAnchor, constant: 16),
+            titleLabel.trailingAnchor.constraint(equalTo: cardView.trailingAnchor, constant: -16),
+
+            idLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 20),
+            idLabel.leadingAnchor.constraint(equalTo: cardView.leadingAnchor, constant: 16),
+            idLabel.trailingAnchor.constraint(equalTo: cardView.trailingAnchor, constant: -16),
+
+            employeeTextField.topAnchor.constraint(equalTo: idLabel.bottomAnchor, constant: 8),
+            employeeTextField.leadingAnchor.constraint(equalTo: cardView.leadingAnchor, constant: 16),
+            employeeTextField.trailingAnchor.constraint(equalTo: cardView.trailingAnchor, constant: -16),
+
+            infoCardView.topAnchor.constraint(equalTo: employeeTextField.bottomAnchor, constant: 20),
+            infoCardView.leadingAnchor.constraint(equalTo: employeeTextField.leadingAnchor),
+            infoCardView.trailingAnchor.constraint(equalTo: employeeTextField.trailingAnchor),
+
+            infoTitleLabel.topAnchor.constraint(equalTo: infoCardView.topAnchor, constant: 12),
+            infoTitleLabel.leadingAnchor.constraint(equalTo: infoCardView.leadingAnchor, constant: 12),
+            infoTitleLabel.trailingAnchor.constraint(equalTo: infoCardView.trailingAnchor, constant: -12),
+
+            infoLabel.topAnchor.constraint(equalTo: infoTitleLabel.bottomAnchor, constant: 4),
+            infoLabel.leadingAnchor.constraint(equalTo: infoCardView.leadingAnchor, constant: 12),
+            infoLabel.trailingAnchor.constraint(equalTo: infoCardView.trailingAnchor, constant: -12),
+            infoLabel.bottomAnchor.constraint(equalTo: infoCardView.bottomAnchor, constant: -12),
+
+            inviteButton.topAnchor.constraint(equalTo: infoCardView.bottomAnchor, constant: 24),
+            inviteButton.leadingAnchor.constraint(equalTo: employeeTextField.leadingAnchor),
+            inviteButton.trailingAnchor.constraint(equalTo: employeeTextField.trailingAnchor),
+            inviteButton.bottomAnchor.constraint(equalTo: cardView.bottomAnchor, constant: -24),
+            inviteButton.heightAnchor.constraint(equalToConstant: 48)
+        ])
+    }
+}

--- a/safe/Sources/View/RegisterCrewView.swift
+++ b/safe/Sources/View/RegisterCrewView.swift
@@ -7,8 +7,6 @@
 
 import UIKit
 
-
-
 class RegisterCrewView: UIView {
 
     private let cardView: UIView = {

--- a/safe/Sources/View/RegisterCrewView.swift
+++ b/safe/Sources/View/RegisterCrewView.swift
@@ -48,7 +48,6 @@ class RegisterCrewView: UIView {
         return textField
     }()
     
-    // infoLabel을 감싸는 카드 뷰 추가
     private let infoCardView: UIView = {
         let view = UIView()
         view.backgroundColor = UIColor(red: 0.9, green: 0.95, blue: 1.0, alpha: 1.0)


### PR DESCRIPTION
근로자 관리 탭 구현
- 현장 현황: 근로자의 근무중/휴식중/오프라인 카운트 표시.
-  근로자 목록: 근로자의 이름, 전화번호, 사번, 근무중/휴식중/오프라인 표시.
-  근로자 목록: (전체)휴식 알림 버튼(알림만 나오게 구현), 개별 메세지 버튼 -> 공지 탭으로 이동 후 버튼을 눌렀던 유저 포커싱
-  근로자 등록: 사번을 입력하면  현재 로그인한 관리자의 회사명과 비교해서 해당 사번이 같은 회사일 경우 등록 및 예외처리 구현
-  개별 메세지: 현재 등록된 근로자를 표시 및 선택 가능, 텍스트 필드에 메세지 입력후 메세지 전송 버튼 누르면 전송되었다는 알림 구현. (실제 전송은 구현하지 않음)